### PR TITLE
remove sign to send slack message

### DIFF
--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,8 +1,6 @@
 %div.menu
   %a.btn.btn-default{:href => entries_path(date: Date.current), :role => "button"} Today
   %a.btn.btn-default.glyphicon.glyphicon-calendar
-  = link_to send_message_entries_path, method: :post do
-    %span.btn.btn-default.glyphicon.glyphicon-bullhorn
   = link_to edit_user_path(current_user) do
     %span.btn.btn-default.glyphicon.glyphicon-user
 %br


### PR DESCRIPTION
#50-character subject line
# 
#72-character wrapped longer description. This should answer:
# 
# \* Why was this change necessary?
# \* How does it address the problem?
# \* Are there any side effects?
# 
# Include a link to the ticket, if any.
